### PR TITLE
Update Video.php

### DIFF
--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -47,6 +47,11 @@ class Video extends AbstractVideo
      */
     public function concat($sources)
     {
+        if(is_array($sources) && (count($sources) > 0)) {
+            array_unshift($sources,$this->pathfile);
+        }else{
+            $sources = array($this->pathfile,$sources);
+        }
         return new Concat($sources, $this->driver, $this->ffprobe);
     }
 


### PR DESCRIPTION
when the video already has a pathfile,the sources add it

| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### Why?

// In order to instantiate the video object, you HAVE TO pass a path to a valid video file.
// We recommend that you put there the path of any of the video you want to use in this concatenation.
```php
$video = $ffmpeg->open( '/path/to/video' );
$video
    ->concat(array('/path/to/video1', '/path/to/video2'))
    ->saveFromSameCodecs('/path/to/new_file', TRUE);

//the result  do not contain the video already opened